### PR TITLE
Fix: Documentation about minimal Android Studio version incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Easily setup a secure chat with the Parley Messaging Android library. The Parley
 ## Requirements
 
 - Android 4.1+ (API 16+)
-- Android Studio 3.5+
+- Android Studio 4.2+ (Android Gradle Plugin 4.2+)
 - Using AndroidX artifacts
 - Permissions (automatically added by the library)
   - android.permission.INTERNET - Required for chatting


### PR DESCRIPTION
While using the latest version of Parley, my team noticed that this version did not play nicely with Android Studio (more specifically Android Gradle Plugin) versions below 4.2.

This PR updates the documentation to reflect what we believe is the actual minimum required Android Studio and Android Gradle Plugin version.