### PR TITLE
Fix: Position of EditText in relation to send button in compose view

### DIFF
--- a/parley/src/main/res/layout/view_compose.xml
+++ b/parley/src/main/res/layout/view_compose.xml
@@ -10,7 +10,7 @@
         android:id="@+id/input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
+        android:layout_gravity="center_vertical"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
         android:layout_weight="1"


### PR DESCRIPTION
If the send button is bigger in height than the EditText, the EditText would be aligned to the bottom (in the available vertical space), that however looks ugly. Now if the send button is bigger in height the EditText will be centered in the available vertical space.