### PR TITLE
Add: ParleyView.setLaunchCallback to change how Parley launches Activities

### DIFF
--- a/parley/src/main/java/nu/parley/android/DefaultParleyLaunchCallback.java
+++ b/parley/src/main/java/nu/parley/android/DefaultParleyLaunchCallback.java
@@ -1,0 +1,36 @@
+package nu.parley.android;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+
+public class DefaultParleyLaunchCallback implements ParleyLaunchCallback {
+
+    private final Context context;
+
+    public DefaultParleyLaunchCallback(@NonNull Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public void launchParleyActivity(Intent intent) {
+        context.startActivity(intent);
+    }
+
+    @Override
+    public void launchParleyActivityForResult(Intent intent, int requestCode) {
+        ((Activity) context).startActivityForResult(intent, requestCode);
+    }
+
+    @Override
+    public void launchParleyPermissionRequest(String[] permissions, int requestCode) {
+        ActivityCompat.requestPermissions(
+                (Activity) context,
+                permissions,
+                requestCode
+        );
+    }
+}

--- a/parley/src/main/java/nu/parley/android/ParleyLaunchCallback.java
+++ b/parley/src/main/java/nu/parley/android/ParleyLaunchCallback.java
@@ -1,0 +1,31 @@
+package nu.parley.android;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import androidx.core.app.ActivityCompat;
+
+public interface ParleyLaunchCallback {
+
+    /**
+     * Called when Parley wants to start an activity, redirect this to
+     * {@link Activity#startActivity(Intent)} or any other method that allows an app to open an Activity.
+     */
+    void launchParleyActivity(Intent intent);
+
+    /**
+     * Called when Parley wants to start an activity and await its result, redirect this to
+     * {@link Activity#startActivityForResult(Intent, int)}  or
+     * {@link androidx.fragment.app.Fragment#startActivityForResult(Intent, int)}. Depending on this
+     * you may need to update where you call {@link Parley#onActivityResult(int, int, Intent)}.
+     */
+    void launchParleyActivityForResult(Intent intent, int requestCode);
+
+    /**
+     * Called when Parley wants to request a permission, redirect this to
+     * {@link ActivityCompat#requestPermissions(Activity, String[], int)} or
+     * {@link androidx.fragment.app.Fragment#requestPermissions(String[], int)}. Depending on this
+     * you may need to update where you call {@link Parley#onRequestPermissionsResult(int, String[], int[])}.
+     */
+    void launchParleyPermissionRequest(String[] permissions, int requestCode);
+}

--- a/parley/src/main/java/nu/parley/android/ParleyLaunchCallback.java
+++ b/parley/src/main/java/nu/parley/android/ParleyLaunchCallback.java
@@ -9,7 +9,8 @@ public interface ParleyLaunchCallback {
 
     /**
      * Called when Parley wants to start an activity, redirect this to
-     * {@link Activity#startActivity(Intent)} or any other method that allows an app to open an Activity.
+     * {@link Activity#startActivity(Intent)} or to the respective Fragment one
+     * ({@link androidx.fragment.app.Fragment#startActivity(Intent)}.
      */
     void launchParleyActivity(Intent intent);
 
@@ -17,7 +18,9 @@ public interface ParleyLaunchCallback {
      * Called when Parley wants to start an activity and await its result, redirect this to
      * {@link Activity#startActivityForResult(Intent, int)}  or
      * {@link androidx.fragment.app.Fragment#startActivityForResult(Intent, int)}. Depending on this
-     * you may need to update where you call {@link Parley#onActivityResult(int, int, Intent)}.
+     * implementation, the `onActivityResult` method will be called in either the Activity or the
+     * Fragment. This `onActivityResult` must be forwarded to
+     * {@link Parley#onActivityResult(int, int, Intent)}
      */
     void launchParleyActivityForResult(Intent intent, int requestCode);
 
@@ -25,7 +28,9 @@ public interface ParleyLaunchCallback {
      * Called when Parley wants to request a permission, redirect this to
      * {@link ActivityCompat#requestPermissions(Activity, String[], int)} or
      * {@link androidx.fragment.app.Fragment#requestPermissions(String[], int)}. Depending on this
-     * you may need to update where you call {@link Parley#onRequestPermissionsResult(int, String[], int[])}.
+     * implementation, the `onRequestPermissionsResult` method will be called in either the Activity
+     * or the Fragment. This `onRequestPermissionsResult` must be forwarded to
+     * {@link Parley#onRequestPermissionsResult(int, String[], int[])}
      */
     void launchParleyPermissionRequest(String[] permissions, int requestCode);
 }

--- a/parley/src/main/java/nu/parley/android/view/ParleyView.java
+++ b/parley/src/main/java/nu/parley/android/view/ParleyView.java
@@ -27,7 +27,9 @@ import com.google.android.material.snackbar.Snackbar;
 
 import java.util.List;
 
+import nu.parley.android.DefaultParleyLaunchCallback;
 import nu.parley.android.Parley;
+import nu.parley.android.ParleyLaunchCallback;
 import nu.parley.android.ParleyListener;
 import nu.parley.android.R;
 import nu.parley.android.data.messages.MessagesManager;
@@ -65,7 +67,8 @@ public final class ParleyView extends FrameLayout implements ParleyListener, Con
     private Listener listener;
     private ConnectivityMonitor connectivityMonitor;
     private ParleyComposeListener composeListener = new ParleyComposeListener();
-    private MessageAdapter adapter = new MessageAdapter(new ParleyMessageListener());
+    private ParleyMessageListener parleyMessageListener = new ParleyMessageListener();
+    private MessageAdapter adapter = new MessageAdapter(parleyMessageListener);
     // Is typing
     private Handler isTypingAgentHandler = new Handler();
     private Runnable isTypingAgentRunnable = null;
@@ -86,6 +89,18 @@ public final class ParleyView extends FrameLayout implements ParleyListener, Con
         super(context, attrs, defStyle);
         init();
         applyStyle(attrs);
+    }
+
+    /**
+     * Allows setting a {@link ParleyLaunchCallback} which allows client apps to change how Parley
+     * "starts an Activity for result" and requests permissions.
+     */
+    public void setLaunchCallback(@Nullable ParleyLaunchCallback launchCallback) {
+        if(launchCallback == null) {
+            launchCallback = new DefaultParleyLaunchCallback(getContext());
+        }
+        parleyMessageListener.setLaunchCallback(launchCallback);
+        composeView.setLaunchCallback(launchCallback);
     }
 
     public void setListener(@Nullable Listener listener) {
@@ -132,6 +147,7 @@ public final class ParleyView extends FrameLayout implements ParleyListener, Con
         composeView = findViewById(R.id.compose_view);
 
         // Configure
+        setLaunchCallback(new DefaultParleyLaunchCallback(getContext()));
         recyclerView.setAdapter(adapter);
         composeView.setStartTypingTriggerInterval(TIME_TYPING_START_TRIGGER);
         composeView.setStopTypingTriggerTime(TIME_TYPING_STOP_TRIGGER);

--- a/parley/src/main/java/nu/parley/android/view/chat/ParleyMessageListener.java
+++ b/parley/src/main/java/nu/parley/android/view/chat/ParleyMessageListener.java
@@ -8,6 +8,8 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
 import com.bumptech.glide.Glide;
 import com.google.android.material.snackbar.Snackbar;
 
@@ -16,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import nu.parley.android.Parley;
+import nu.parley.android.ParleyLaunchCallback;
 import nu.parley.android.R;
 import nu.parley.android.data.model.Action;
 import nu.parley.android.data.model.Message;
@@ -23,6 +26,8 @@ import nu.parley.android.imageviewer.ImageViewer;
 import nu.parley.android.imageviewer.ImageViewerLoader;
 
 public final class ParleyMessageListener implements MessageListener {
+
+    private ParleyLaunchCallback launchCallback;
 
     @Override
     public void onRetryMessageClicked(Message message) {
@@ -67,14 +72,18 @@ public final class ParleyMessageListener implements MessageListener {
         try {
             Intent intent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
             if (intent != null) {
-                view.getContext().startActivity(intent);
+                launchCallback.launchParleyActivity(intent);
             } else {
                 Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                view.getContext().startActivity(browserIntent);
+                launchCallback.launchParleyActivity(browserIntent);
             }
         } catch (URISyntaxException | ActivityNotFoundException e) {
             e.printStackTrace();
             Snackbar.make(view, R.string.parley_error_action_open, Snackbar.LENGTH_LONG).show();
         }
+    }
+
+    public void setLaunchCallback(@NonNull ParleyLaunchCallback launchCallback) {
+        this.launchCallback = launchCallback;
     }
 }

--- a/parley/src/main/java/nu/parley/android/view/compose/ComposeImageInputView.java
+++ b/parley/src/main/java/nu/parley/android/view/compose/ComposeImageInputView.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatImageView;
 import androidx.core.app.ActivityCompat;
@@ -27,6 +28,7 @@ import androidx.core.app.ActivityCompat;
 import java.io.File;
 import java.io.IOException;
 
+import nu.parley.android.ParleyLaunchCallback;
 import nu.parley.android.R;
 import nu.parley.android.util.FileUtil;
 import nu.parley.android.util.ParleyPermissionUtil;
@@ -36,6 +38,7 @@ import nu.parley.android.view.ParleyView;
 public final class ComposeImageInputView extends FrameLayout implements View.OnClickListener {
 
     private AppCompatImageView cameraImageView;
+    private ParleyLaunchCallback launchCallback;
 
     private File currentPhotoPath;
 
@@ -116,8 +119,7 @@ public final class ComposeImageInputView extends FrameLayout implements View.OnC
 
     private void checkCameraAccess() {
         if (ParleyPermissionUtil.shouldRequestPermission(getContext(), Manifest.permission.CAMERA)) {
-            ActivityCompat.requestPermissions(
-                    (Activity) getContext(),
+            launchCallback.launchParleyPermissionRequest(
                     new String[]{Manifest.permission.CAMERA},
                     ParleyView.REQUEST_PERMISSION_ACCESS_CAMERA
             );
@@ -144,7 +146,7 @@ public final class ComposeImageInputView extends FrameLayout implements View.OnC
     }
 
     private void launchIntent(Intent intent, int requestCode) {
-        ((Activity) getContext()).startActivityForResult(intent, requestCode);
+        launchCallback.launchParleyActivityForResult(intent, requestCode);
     }
 
     public void setImageDrawable(Drawable drawable) {
@@ -153,5 +155,9 @@ public final class ComposeImageInputView extends FrameLayout implements View.OnC
 
     public void setImageTintList(ColorStateList color) {
         cameraImageView.setSupportImageTintList(color);
+    }
+
+    public void setLaunchCallback(@NonNull ParleyLaunchCallback launchCallback) {
+        this.launchCallback = launchCallback;
     }
 }

--- a/parley/src/main/java/nu/parley/android/view/compose/ParleyComposeView.java
+++ b/parley/src/main/java/nu/parley/android/view/compose/ParleyComposeView.java
@@ -15,6 +15,7 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
@@ -22,6 +23,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.io.File;
 
+import nu.parley.android.ParleyLaunchCallback;
 import nu.parley.android.R;
 import nu.parley.android.util.FileUtil;
 import nu.parley.android.util.StyleUtil;
@@ -255,5 +257,9 @@ public final class ParleyComposeView extends FrameLayout implements View.OnClick
         inputEditText.setEnabled(enabled);
         imageInputView.setEnabled(enabled);
         sendButton.setEnabled(enabled);
+    }
+
+    public void setLaunchCallback(@NonNull ParleyLaunchCallback launchCallback) {
+        imageInputView.setLaunchCallback(launchCallback);
     }
 }


### PR DESCRIPTION
Currently the Parley library is forcing us to handle Activity results or permission request results inside Activities. Workarounds to handle these results in Fragments can be done, for example getting the instance of the Fragment that hosts the ParleyView and passing the results to that Fragment from the Activity, however that is not a perfect solution and requires some very strictly coupled code between the Activity and Fragment. We prefer to keep our Activities and Fragments separated in such a way that they don't really know about each other.
 
This pull-requests adds a callback/listener that allows client applications to change how Parley launches Activities and permission requests. By allowing these to be intercepted, client applications can change whether the Activity starts these Activities or request, or whether a Fragment does this.

This is a minimal implementation from my side, if you have suggestions please let me know.
