### PR TITLE
Fix: crash when showing the 'agent typing' message

### DIFF
--- a/parley/src/main/java/nu/parley/android/view/chat/holder/AgentTypingMessageViewHolder.java
+++ b/parley/src/main/java/nu/parley/android/view/chat/holder/AgentTypingMessageViewHolder.java
@@ -59,7 +59,7 @@ public final class AgentTypingMessageViewHolder extends ParleyBaseViewHolder {
         contentLayout.setBackground(StyleUtil.getDrawable(getContext(), ta, R.styleable.ParleyMessageAgentTyping_parley_background));
         StyleUtil.Helper.applyBackgroundColor(contentLayout, ta, R.styleable.ParleyMessageAgentTyping_parley_background_tint_color);
 
-        StyleUtil.StyleSpacing styleSpacingMargin = StyleUtil.getSpacingData(ta, R.styleable.ParleyMessageAgentTyping_parley_margin, R.styleable.ParleyMessageAgentTyping_parley_margin_top, R.styleable.ParleyMessageAgentTyping_parley_margin_right, R.styleable.ParleyMessageBase_parley_margin_bottom, R.styleable.ParleyMessageAgentTyping_parley_margin_left);
+        StyleUtil.StyleSpacing styleSpacingMargin = StyleUtil.getSpacingData(ta, R.styleable.ParleyMessageAgentTyping_parley_margin, R.styleable.ParleyMessageAgentTyping_parley_margin_top, R.styleable.ParleyMessageAgentTyping_parley_margin_right, R.styleable.ParleyMessageAgentTyping_parley_margin_bottom, R.styleable.ParleyMessageAgentTyping_parley_margin_left);
         itemView.setPadding(styleSpacingMargin.left, styleSpacingMargin.top, styleSpacingMargin.right, styleSpacingMargin.bottom);
         StyleUtil.StyleSpacing styleSpacingPadding = StyleUtil.getSpacingData(ta, R.styleable.ParleyMessageAgentTyping_parley_content_padding, R.styleable.ParleyMessageAgentTyping_parley_content_padding_top, R.styleable.ParleyMessageAgentTyping_parley_content_padding_right, R.styleable.ParleyMessageAgentTyping_parley_content_padding_bottom, R.styleable.ParleyMessageAgentTyping_parley_content_padding_left);
         contentLayout.setPadding(styleSpacingPadding.left, styleSpacingPadding.top, styleSpacingPadding.right, styleSpacingPadding.bottom);


### PR DESCRIPTION
This crash was caused by referencing a styleable index that is not available in the requested styleable:

```
java.lang.UnsupportedOperationException: Can't convert value at index 15 to dimension: type=0x1
        at android.content.res.TypedArray.getDimensionPixelSize(TypedArray.java:787)
        at nu.parley.android.util.StyleUtil.getDimension(StyleUtil.java:100)
        at nu.parley.android.util.StyleUtil.getSpacingData(StyleUtil.java:91)
        at nu.parley.android.view.chat.holder.AgentTypingMessageViewHolder.applyStyle(AgentTypingMessageViewHolder.java:62)
        at nu.parley.android.view.chat.holder.AgentTypingMessageViewHolder.<init>(AgentTypingMessageViewHolder.java:32)
        at nu.parley.android.view.chat.MessageViewHolderFactory.getViewHolder(MessageViewHolderFactory.java:41)
        at nu.parley.android.view.chat.MessageAdapter.onCreateViewHolder(MessageAdapter.java:31)
        at nu.parley.android.view.chat.MessageAdapter.onCreateViewHolder(MessageAdapter.java:18)
        at androidx.recyclerview.widget.RecyclerView$Adapter.createViewHolder(RecyclerView.java:7078)
        at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:6235)
        at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6118)
        at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6114)
```

It would be really helpful if this can be fixed/merged/released ASAP, since this is something that is 100% reproducible for all users.