### PR TITLE
Add new certificate for 2023 -> 2024

### DIFF
--- a/parley/src/main/res/xml/parley_network_security_config.xml
+++ b/parley/src/main/res/xml/parley_network_security_config.xml
@@ -6,8 +6,8 @@
         <domain includeSubdomains="true">parley.nu</domain>
 
         <pin-set>
-            <pin digest="SHA-256">J2Aa4z+8R9zmgCOGJExzEYpYzNHGiHf4pa6lKmY5wAM=</pin> <!-- Expires at: 21 Aug 2022 -->
             <pin digest="SHA-256">V5O+jBKXrJl+8lAfQJCEp5a/zck+eiDn78TgTNDs3QY=</pin> <!-- Expires at: 29 Jul 2023 -->
+            <pin digest="SHA-256">1sZDlYipkuCiocCIY+1NHeP/GzCYj5nsxFaHYKQtFJg=</pin> <!-- Expires at: 27 Jun 2024 -->
         </pin-set>
         <trustkit-config enforcePinning="true"/>
 


### PR DESCRIPTION
Add new certificate for SSL pinning

Old certificate: 28-07-2022 until 29-07-2023
New certificate: 26-06-2023 until 27-06-2024

Previous PR from last year: https://github.com/parley-messaging/android-library/pull/17
Please release this in a new version.