### PR TITLE
Add option to set okhttp interceptor to network client

### DIFF
--- a/parley/src/main/java/nu/parley/android/ParleyNetwork.java
+++ b/parley/src/main/java/nu/parley/android/ParleyNetwork.java
@@ -1,11 +1,14 @@
 package nu.parley.android;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.XmlRes;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import nu.parley.android.data.model.ApiVersion;
+import okhttp3.Interceptor;
 
 /**
  * Provides the network configuration for Parley.
@@ -17,6 +20,8 @@ public final class ParleyNetwork {
 
     public final String url;
     public final Map<String, String> headers;
+    @Nullable
+    public Interceptor interceptor;
     @XmlRes
     final Integer securityConfigResourceFile;
     public final String path;
@@ -62,6 +67,18 @@ public final class ParleyNetwork {
         this.apiVersion = apiVersion;
         this.securityConfigResourceFile = securityConfigResourceFile;
         this.headers = headers;
+    }
+
+
+    /**
+     * Sets the network interceptor for the Parley client.
+     *
+     * @param interceptor the interceptor to set
+     * @return the current instance of the Parley network configuration
+     */
+    public ParleyNetwork setInterceptor(Interceptor interceptor) {
+        this.interceptor = interceptor;
+        return this;
     }
 
     /**

--- a/parley/src/main/java/nu/parley/android/data/net/Connectivity.java
+++ b/parley/src/main/java/nu/parley/android/data/net/Connectivity.java
@@ -69,6 +69,8 @@ public final class Connectivity {
                 .readTimeout(30, TimeUnit.SECONDS)
                 .writeTimeout(30, TimeUnit.SECONDS);
 
+        okHttpClientBuilder = addInterceptor(okHttpClientBuilder);
+
         applySslPinning(okHttpClientBuilder);
 
         return okHttpClientBuilder.build();
@@ -115,6 +117,19 @@ public final class Connectivity {
 
             requestBuilder.addHeader(name, value);
         }
+    }
+
+    /**
+     * Adds an interceptor to the OkHttpClient.Builder.
+     *
+     * @param builder the OkHttpClient.Builder to add the interceptor to.
+     * @return the OkHttpClient.Builder with the added interceptor.
+     */
+    private static OkHttpClient.Builder addInterceptor(OkHttpClient.Builder builder) {
+        if (Parley.getInstance().getNetwork().interceptor != null) {
+            return builder.addInterceptor(Parley.getInstance().getNetwork().interceptor);
+        }
+        return builder;
     }
 
     /**


### PR DESCRIPTION
For Parley to be able to connect to the backend api's hosted on our servers, we need to add some extra headers. Setting pre-configured headers using the `Map<String, String> headers` parameter doesn't work for us, because our headers need to be created dynamically. 

This change would allow is to add the custom headers we need. 

I considered adding a new ParleyNetwork constructor, but this would require the client to add the OkHttp networking library (or Retrofit) to be abled to compile the project. That's why I've added a function instead.

Thanks,

Menno Vogel