### PR TITLE
add possibility to disable default push permission dialog and channel…

### DIFF
--- a/parley/src/main/java/nu/parley/android/Parley.java
+++ b/parley/src/main/java/nu/parley/android/Parley.java
@@ -73,7 +73,7 @@ public final class Parley {
     private boolean loadingMore = false;
     private boolean refreshingMessages = false;
 
-    private boolean doRequestPushPermission = true;
+    private boolean requestNotificationPermission = true;
 
     private Parley() {
         // Hide default constructor
@@ -244,12 +244,12 @@ public final class Parley {
         getInstance().messagesManager.disableCaching();
     }
 
-    public static void disableRequestPushPermission() {
-        getInstance().doRequestPushPermission = false;
+    public static void setRequestNotificationPermission(Boolean permission) {
+        getInstance().requestNotificationPermission = permission;
     }
 
-    public static Boolean doRequestPushPermission() {
-        return getInstance().doRequestPushPermission;
+    public static Boolean getRequestNotificationPermission() {
+        return getInstance().requestNotificationPermission;
     }
 
     /**

--- a/parley/src/main/java/nu/parley/android/Parley.java
+++ b/parley/src/main/java/nu/parley/android/Parley.java
@@ -73,6 +73,8 @@ public final class Parley {
     private boolean loadingMore = false;
     private boolean refreshingMessages = false;
 
+    private boolean doRequestPushPermission = true;
+
     private Parley() {
         // Hide default constructor
     }
@@ -240,6 +242,14 @@ public final class Parley {
     @SuppressWarnings("unused")
     public static void disableOfflineMessaging() {
         getInstance().messagesManager.disableCaching();
+    }
+
+    public static void disableRequestPushPermission() {
+        getInstance().doRequestPushPermission = false;
+    }
+
+    public static Boolean doRequestPushPermission() {
+        return getInstance().doRequestPushPermission;
     }
 
     /**

--- a/parley/src/main/java/nu/parley/android/view/ParleyView.java
+++ b/parley/src/main/java/nu/parley/android/view/ParleyView.java
@@ -295,7 +295,9 @@ public final class ParleyView extends FrameLayout implements ParleyListener, Con
             Parley.getInstance().setListener(this);
             connectivityMonitor.register(getContext(), this);
             accessibilityMonitor.register(getContext(), this);
-            requestPermissionsIfNeeded();
+            if (Parley.doRequestPushPermission()) {
+                requestPermissionsIfNeeded();
+            }
         } else {
             Parley.getInstance().clearListener();
             connectivityMonitor.unregister(getContext());

--- a/parley/src/main/java/nu/parley/android/view/ParleyView.java
+++ b/parley/src/main/java/nu/parley/android/view/ParleyView.java
@@ -295,7 +295,7 @@ public final class ParleyView extends FrameLayout implements ParleyListener, Con
             Parley.getInstance().setListener(this);
             connectivityMonitor.register(getContext(), this);
             accessibilityMonitor.register(getContext(), this);
-            if (Parley.doRequestPushPermission()) {
+            if (Parley.getRequestNotificationPermission()) {
                 requestPermissionsIfNeeded();
             }
         } else {


### PR DESCRIPTION
For the Triodos App we would gain control over the Push Permission Dialog and over the channels. By adding an extra setting, we can suppress the default dialog.

Regards,
Diederick Verweij
diederick.verweij@triodos.com