### PR TITLE
Prevent NPE for call parleyErrorResponse.getNotification

### DIFF
--- a/parley/src/main/java/nu/parley/android/data/net/response/ParleyErrorResponse.java
+++ b/parley/src/main/java/nu/parley/android/data/net/response/ParleyErrorResponse.java
@@ -19,7 +19,7 @@ public final class ParleyErrorResponse {
 
     @Nullable
     private ParleyNotificationResponse getNotification() {
-        if (notifications.isEmpty()) {
+        if (notifications == null || notifications.isEmpty()) {
             return null;
         }
         return notifications.get(0);


### PR DESCRIPTION
Our proxy currently doesn't return the right (read: expected) json error structure, this results in a crash. This change will prevent that crash. We'll need to deal with handling the errors but first we'll need to prevent the crash.
It would be cool if you could merge this into master and bump to >3.9.3

Kind Regards,
Diederick
Kotlin/Android developer
Triodos