### PR TITLE
Add new certificate for 2024 -> 2025

### DIFF
--- a/parley/src/main/res/xml/parley_network_security_config.xml
+++ b/parley/src/main/res/xml/parley_network_security_config.xml
@@ -6,8 +6,7 @@
         <domain includeSubdomains="true">parley.nu</domain>
 
         <pin-set>
-            <pin digest="SHA-256">V5O+jBKXrJl+8lAfQJCEp5a/zck+eiDn78TgTNDs3QY=</pin> <!-- Expires at: 29 Jul 2023 -->
-            <pin digest="SHA-256">1sZDlYipkuCiocCIY+1NHeP/GzCYj5nsxFaHYKQtFJg=</pin> <!-- Expires at: 27 Jun 2024 -->
+            <pin digest="SHA-256">1sZDlYipkuCiocCIY+1NHeP/GzCYj5nsxFaHYKQtFJg=</pin> <!-- Same public key for cert that expires at: 27 Jun 2024 and 28 Jun 2025 -->
         </pin-set>
         <trustkit-config enforcePinning="true"/>
 

--- a/parley/src/main/res/xml/parley_network_security_config.xml
+++ b/parley/src/main/res/xml/parley_network_security_config.xml
@@ -6,6 +6,7 @@
         <domain includeSubdomains="true">parley.nu</domain>
 
         <pin-set>
+            <pin digest="SHA-256">V5O+jBKXrJl+8lAfQJCEp5a/zck+eiDn78TgTNDs3QY=</pin> <!-- Expires at: 29 Jul 2023 -->
             <pin digest="SHA-256">1sZDlYipkuCiocCIY+1NHeP/GzCYj5nsxFaHYKQtFJg=</pin> <!-- Same public key for cert that expires at: 27 Jun 2024 and 28 Jun 2025 -->
         </pin-set>
         <trustkit-config enforcePinning="true"/>


### PR DESCRIPTION
FYI: The public key for the new certificate is the same as the one for the old certificate. This means that the PIN doesn't change. I have removed the old one though.

Below text is just for consistent administration.

---

Add new certificate for SSL pinning

Old certificate: 26-06-2023 until 27-06-2024
New certificate: 27-May-2024 until 28-Jul-2025

Previous PR from last year: https://github.com/parley-messaging/android-library/pull/17
Please release this in a new version.