### PR TITLE
Fixed scroll to bottom with the same messages

### DIFF
--- a/parley/src/main/java/nu/parley/android/Parley.java
+++ b/parley/src/main/java/nu/parley/android/Parley.java
@@ -486,10 +486,10 @@ public final class Parley {
                         messagesManager.applyWelcomeMessage(data.getWelcomeMessage());
 
                         // Detect new messages, and add them
-                        messagesManager.addOnlyNew(data.getData());
+                        boolean didAddNew = messagesManager.addOnlyNew(data.getData());
 
                         // Trigger update to listener
-                        if (listener != null) {
+                        if (listener != null && didAddNew) {
                             listener.onReceivedLatestMessages();
                         }
 

--- a/parley/src/main/java/nu/parley/android/data/messages/MessagesManager.java
+++ b/parley/src/main/java/nu/parley/android/data/messages/MessagesManager.java
@@ -123,8 +123,9 @@ public final class MessagesManager {
      * Adds only the new messages that we did not have in the dataset yet.
      *
      * @param messages A list of messages which may have messages that we have shown earlier
+     * @return True if it did add messages, false if the messages where the same
      */
-    public void addOnlyNew(List<Message> messages) {
+    public boolean addOnlyNew(List<Message> messages) {
         boolean didAddMessage = false;
         Collections.reverse(messages);
 
@@ -155,6 +156,7 @@ public final class MessagesManager {
         if (didAddMessage) {
             formatMessages();
         }
+        return didAddMessage;
     }
 
     public void update(Message message) {


### PR DESCRIPTION
This fixes #53.

I've resolved it by using a boolean to indicate if `addOnlyNew` detected a change, if there was on change `listener.onReceivedLatestMessages()` will not be called.