### PR TITLE
Added option not to resend pending messages on triggerRefreshOnConnected

### DIFF
--- a/parley/src/main/java/nu/parley/android/Parley.java
+++ b/parley/src/main/java/nu/parley/android/Parley.java
@@ -471,6 +471,10 @@ public final class Parley {
     }
 
     public void triggerRefreshOnConnected() {
+        triggerRefreshOnConnected(true);
+    }
+
+    public void triggerRefreshOnConnected(boolean resendPendingMessages) {
         if (this.state == State.UNCONFIGURED || this.state == State.CONFIGURING) {
             // Ignore, we cannot refresh data if we are not configured yet or if we are already configuring
             return;
@@ -507,7 +511,9 @@ public final class Parley {
                             listener.onReceivedLatestMessages();
                         }
 
-                        resendPendingMessages(messagesManager.getPendingMessages(true));
+                        if (resendPendingMessages) {
+                            resendPendingMessages(messagesManager.getPendingMessages(true));
+                        }
 
                         if (state != State.CONFIGURED) {
                             setState(State.CONFIGURED);


### PR DESCRIPTION
By adding the option not to resend pending messages when triggerRefreshOnConnected is called we fix a bug that results in duplicate messages being send. 

This can be reproduced if you call `Parley.getInstance().triggerRefreshOnConnected();` at the same that a message is being send. It's easy to reproduce this if you add this code to `ChatActivity.java` and send a few messages in the demo project:

```
    @Override
    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_chat);

        setupToolbar();

        parleyView = findViewById(R.id.parley_view);

        refreshDelayed();

        setParleyViewSettings();
    }

    private void refreshDelayed() {
        new Handler(Looper.myLooper()).postDelayed(new Runnable() {
            @Override
            public void run() {
                Parley.getInstance().triggerRefreshOnConnected(true);
                refreshDelayed();
            }
        }, 150);
    }
```

Also check out this video: 

https://github.com/parley-messaging/android-library/assets/2795333/c1870b52-8c1c-4a9b-b2bd-f8722dc7d86d

With this fix we can call Parley.getInstance().triggerRefreshOnConnected(false); to prevent the duplicate messages.

Note: The solution could maybe be resolved in a better way. For example by adding another Message status type, like `SEND_STATUS_SENDING`, but this would be a larger refactor and I'm not sure if I can test all cases.