### PR TITLE
Skip focus on container when message is text only

### DIFF
--- a/parley/src/main/java/nu/parley/android/data/model/Message.java
+++ b/parley/src/main/java/nu/parley/android/data/model/Message.java
@@ -321,6 +321,19 @@ public final class Message {
                 !hasActionsContent();
     }
 
+    /**
+     * Determine whether this message consistes of only text as content.
+     *
+     * @return `true` if the content of the message is text only, `false` otherwise.
+     */
+    public boolean isTextOnly() {
+        return hasTextContent() &&
+                !hasActionsContent() &&
+                !hasImageContent() &&
+                !hasFileContent() &&
+                !hasCarouselContent();
+    }
+
     public boolean hasName() {
         return getAgent() != null && !agent.getName().trim().isEmpty();
     }

--- a/parley/src/main/java/nu/parley/android/view/BalloonView.java
+++ b/parley/src/main/java/nu/parley/android/view/BalloonView.java
@@ -140,6 +140,11 @@ public final class BalloonView extends FrameLayout {
         messageTextView.setMovementMethod(LinkMovementMethod.getInstance());
     }
 
+    public void setContainerFocusable(boolean isFocusable) {
+        contentLayout.setFocusable(isFocusable);
+        contentLayout.setFocusableInTouchMode(isFocusable);
+    }
+
     public void style(@StyleRes int messageStyle) {
         fileView.style(messageStyle);
     }

--- a/parley/src/main/java/nu/parley/android/view/chat/holder/MessageViewHolder.java
+++ b/parley/src/main/java/nu/parley/android/view/chat/holder/MessageViewHolder.java
@@ -152,6 +152,7 @@ public abstract class MessageViewHolder extends ParleyBaseViewHolder {
 
         // Accessibility
         balloonView.setContentDescription(AccessibilityUtil.getContentDescription(itemView, message));
+        if (message.isTextOnly()) balloonView.setContainerFocusable(false);
     }
 
     @Nullable


### PR DESCRIPTION
Do not highlight "bubble" container when message is a text only.