### PR TITLE
Made a background color block for times in the messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.11.3 - Unreleased
+- [Accessibility] Added configurable background color to time in messages.
+
 ## 3.11.2 - Released 14 Mar 2025
 
 - [Accessibility] Fixed not being able to open images when using TalkBack.

--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ task clean(type: Delete) {
 }
 
 ext {
-    parley_version_name = "3.11.2"
+    parley_version_name = "3.11.3"
 }

--- a/parley/src/main/java/nu/parley/android/view/BalloonView.java
+++ b/parley/src/main/java/nu/parley/android/view/BalloonView.java
@@ -80,6 +80,7 @@ public final class BalloonView extends FrameLayout {
 
     private ViewGroup metaLayout;
     private TextView timeTextView;
+    private FrameLayout timeBackgroundView;
     private ViewGroup statusLayout;
     private AppCompatImageView statusImageView;
 
@@ -91,6 +92,7 @@ public final class BalloonView extends FrameLayout {
     private ColorStateList messageTimeColor;
     private ColorStateList messageStatusColor;
     private ColorStateList imageTimeColor;
+    private ColorStateList timeBackgroundColor;
     private ColorStateList imageStatusColor;
 
     public BalloonView(Context context) {
@@ -130,6 +132,7 @@ public final class BalloonView extends FrameLayout {
 
         metaLayout = findViewById(R.id.meta_layout);
         timeTextView = findViewById(R.id.time_text_view);
+        timeBackgroundView = findViewById(R.id.time_background_view);
         statusLayout = findViewById(R.id.status_layout);
         statusImageView = findViewById(R.id.status_image_view);
 
@@ -383,8 +386,8 @@ public final class BalloonView extends FrameLayout {
 
     public void refreshStyle(boolean isMetaOnImage) {
         timeTextView.setTextColor(isMetaOnImage ? imageTimeColor : messageTimeColor);
+        timeBackgroundView.setBackgroundTintList(timeBackgroundColor);
         ImageViewCompat.setImageTintList(statusImageView, isMetaOnImage ? imageStatusColor : messageStatusColor);
-
         metaShadowView.setVisibility(isMetaOnImage ? View.VISIBLE : View.GONE);
     }
 
@@ -424,6 +427,10 @@ public final class BalloonView extends FrameLayout {
         this.messageTimeColor = messageTimeColor;
         this.imageTimeColor = imageTimeColor;
         this.infoTextView.setTextColor(imageTimeColor);
+    }
+
+    public void setTimeBackground(ColorStateList timeBackgroundColor) {
+        this.timeBackgroundColor = timeBackgroundColor;
     }
 
     public void setTimeFont(Typeface font, int style) {

--- a/parley/src/main/java/nu/parley/android/view/chat/holder/MessageViewHolder.java
+++ b/parley/src/main/java/nu/parley/android/view/chat/holder/MessageViewHolder.java
@@ -78,7 +78,7 @@ public abstract class MessageViewHolder extends ParleyBaseViewHolder {
         balloonView.setTimeFont(StyleUtil.getFont(getContext(), ta, R.styleable.ParleyMessageBase_parley_time_font_family), StyleUtil.getFontStyle(ta, R.styleable.ParleyMessageBase_parley_time_font_style));
         balloonView.setTimeTextSize(TypedValue.COMPLEX_UNIT_PX, StyleUtil.getDimension(ta, R.styleable.ParleyMessageBase_parley_time_text_size));
         balloonView.setTimeColor(StyleUtil.getColorStateList(ta, R.styleable.ParleyMessageBase_parley_message_time_color), StyleUtil.getColorStateList(ta, R.styleable.ParleyMessageBase_parley_image_time_color));
-
+        balloonView.setTimeBackground(StyleUtil.getColorStateList(ta, R.styleable.ParleyMessageBase_parley_message_time_background_color));
         ta.recycle();
     }
 

--- a/parley/src/main/res/layout/view_balloon.xml
+++ b/parley/src/main/res/layout/view_balloon.xml
@@ -186,14 +186,22 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1" />
 
-                <TextView
-                    android:id="@+id/time_text_view"
+                <FrameLayout
+                    android:id="@+id/time_background_view"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center|start"
-                    android:importantForAccessibility="no"
-                    android:includeFontPadding="false"
-                    tools:text="15:47" />
+                    android:background="@color/parley_background">
+
+                    <TextView
+                        android:id="@+id/time_text_view"
+                        android:layout_marginHorizontal="4dp"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center|start"
+                        android:importantForAccessibility="no"
+                        android:includeFontPadding="false"
+                        tools:text="15:47" />
+                </FrameLayout>
 
                 <FrameLayout
                     android:id="@+id/status_layout"

--- a/parley/src/main/res/values/attrs.xml
+++ b/parley/src/main/res/values/attrs.xml
@@ -272,6 +272,7 @@
         <attr name="parley_time_font_style" />
         <attr name="parley_time_text_size" format="dimension" />
         <attr name="parley_message_time_color" format="color" />
+        <attr name="parley_message_time_background_color" format="color" />
         <attr name="parley_image_time_color" format="color" />
     </declare-styleable>
 

--- a/parley/src/main/res/values/parley_configuration.xml
+++ b/parley/src/main/res/values/parley_configuration.xml
@@ -60,6 +60,7 @@
     </style>
 
     <color name="parley_primary_color">#4A5E83</color>
+    <color name="transparent">#00FFFFFF</color>
 
     <!-- Parley - View -->
     <color name="parley_background">#EAEAEA</color>
@@ -217,7 +218,7 @@
     <dimen name="parley_user_time_text_size">12sp</dimen>
     <color name="parley_user_message_time">#BBC4C8</color>
     <color name="parley_user_image_time">#FFF</color>
-    <color name="parley_user_image_time_background">@color/parley_user_background_tint</color>
+    <color name="parley_user_image_time_background">@color/transparent</color>
     <color name="parley_user_message_status">@color/parley_user_message_time</color>
     <color name="parley_user_image_status">@color/parley_user_image_time</color>
 
@@ -270,7 +271,7 @@
     <dimen name="parley_agent_time_text_size">12sp</dimen>
     <color name="parley_agent_message_time">#BBC4C8</color>
     <color name="parley_agent_image_time">#FFF</color>
-    <color name="parley_agent_image_time_background">@color/parley_agent_background_tint</color>
+    <color name="parley_agent_image_time_background">@color/transparent</color>
     <dimen name="parley_agent_name_padding">@null</dimen>
     <dimen name="parley_agent_name_padding_top">8dp</dimen>
     <dimen name="parley_agent_name_padding_bottom">0dp</dimen>

--- a/parley/src/main/res/values/parley_configuration.xml
+++ b/parley/src/main/res/values/parley_configuration.xml
@@ -217,6 +217,7 @@
     <dimen name="parley_user_time_text_size">12sp</dimen>
     <color name="parley_user_message_time">#BBC4C8</color>
     <color name="parley_user_image_time">#FFF</color>
+    <color name="parley_user_image_time_background">@color/parley_user_background_tint</color>
     <color name="parley_user_message_status">@color/parley_user_message_time</color>
     <color name="parley_user_image_status">@color/parley_user_image_time</color>
 
@@ -269,6 +270,7 @@
     <dimen name="parley_agent_time_text_size">12sp</dimen>
     <color name="parley_agent_message_time">#BBC4C8</color>
     <color name="parley_agent_image_time">#FFF</color>
+    <color name="parley_agent_image_time_background">@color/parley_agent_background_tint</color>
     <dimen name="parley_agent_name_padding">@null</dimen>
     <dimen name="parley_agent_name_padding_top">8dp</dimen>
     <dimen name="parley_agent_name_padding_bottom">0dp</dimen>

--- a/parley/src/main/res/values/styles.xml
+++ b/parley/src/main/res/values/styles.xml
@@ -228,6 +228,7 @@
         <!--<item name="parley_time_font_style">normal</item>-->
         <item name="parley_time_text_size">@dimen/parley_user_time_text_size</item>
         <item name="parley_message_time_color">@color/parley_user_message_time</item>
+        <item name="parley_message_time_background_color">@color/parley_user_image_time_background</item>
         <item name="parley_image_time_color">@color/parley_user_image_time</item>
 
         <!-- User values -->
@@ -296,6 +297,7 @@
         <!--<item name="parley_time_font_style">normal</item>-->
         <item name="parley_time_text_size">@dimen/parley_agent_time_text_size</item>
         <item name="parley_message_time_color">@color/parley_agent_message_time</item>
+        <item name="parley_message_time_background_color">@color/parley_agent_image_time_background</item>
         <item name="parley_image_time_color">@color/parley_agent_image_time</item>
 
         <!-- Agent values -->


### PR DESCRIPTION
Block is configurable through
parley_agent_image_time_background
parley_user_image_time_background

Supported values are hex ( for example: #FFFFFF and for opacity #ffFFFFFF (first two determine level of opacity))

![image (2)](https://github.com/user-attachments/assets/738acbf6-66fd-469d-b6b8-f8ed3d173b92)
