### PR TITLE
Add new certificate for 2025 -> 2026

### DIFF
--- a/parley/src/main/res/xml/parley_network_security_config.xml
+++ b/parley/src/main/res/xml/parley_network_security_config.xml
@@ -4,8 +4,8 @@
         <domain includeSubdomains="true">parley.nu</domain>
 
         <pin-set>
-            <pin digest="SHA-256">V5O+jBKXrJl+8lAfQJCEp5a/zck+eiDn78TgTNDs3QY=</pin> <!-- Expires at: 29 Jul 2023 -->
             <pin digest="SHA-256">1sZDlYipkuCiocCIY+1NHeP/GzCYj5nsxFaHYKQtFJg=</pin> <!-- Same public key for cert that expires at: 27 Jun 2024 and 28 Jun 2025 -->
+            <pin digest="SHA-256">6CjoNLCiYXjhc6mdzEIRP2mszqogXLOgHRiJ24UUZkQ=</pin> <!-- Expires at: 10 Jun 2026 -->
         </pin-set>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Add new certificate for SSL pinning

Old certificate: 27-May-2024 until 27-Jun-2025
New certificate: 09-Jun-2025 until 10-Jun-2026

Previous PR from last year: https://github.com/parley-messaging/android-library/pull/46
Please release this in a new version.

FYI: The public key for the new certificate **CHANGED**!